### PR TITLE
Show curated corpus info in Gradio

### DIFF
--- a/src/build/build_index.py
+++ b/src/build/build_index.py
@@ -48,6 +48,7 @@ def build_index() -> None:
 
     ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
     manifest = {
+        "corpus_name": "Banking Demo Corpus",
         "built_at": datetime.now(UTC).isoformat(),
         "data_dir": str(DATA_DIR),
         "document_count": len(docs),


### PR DESCRIPTION
## Summary
Curates the Gradio demo UI by surfacing corpus metadata and switching doc type selection to a dropdown sourced from the manifest.

## Changes
- Add `corpus_name` to the build manifest output.
- Gradio UI now displays corpus name, build date, doc count, and embedding details.
- Doc type filter is a dropdown populated from manifest `document_types`.

## Testing
- Not run (UI + manifest wiring only).

## Notes
- No build/upload controls existed in the UI, so none were removed.
