### PR TITLE
Align demo artifacts claim and add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tumelo Konaite
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ python -m src.build.build_index
 This writes the Chroma DB under `artifacts/vector_db/` and a `artifacts/manifest.json`
 describing the corpus (document counts, build timestamp, embedding model, etc.).
 
-For the MVP demo, the repo ships with a small prebuilt corpus under `artifacts/`.
-You can run the API + Gradio immediately without re-ingesting documents.
+For the MVP demo, this repo ships with a small prebuilt corpus under `artifacts/`
+(manifest + Chroma DB). You can run the API + Gradio immediately without
+re-ingesting documents. If you remove `artifacts/`, rebuild with
+`python -m src.build.build_index`.
 
 ## Ask questions
 
@@ -256,4 +258,12 @@ If you want to skip auto-tagging for a fork, delete or edit the "Tag successful 
 
 ## License
 
-Specify the license you plan to use for the repository (for example MIT or Apache 2.0). Update this section before publishing publicly.
+MIT License. See `LICENSE`.
+
+## Repository metadata (GitHub “About”)
+
+Suggested description:
+“Demo-ready Banking RAG pipeline with prebuilt artifacts, FastAPI, and Gradio chat UI.”
+
+Suggested topics:
+`rag`, `banking`, `fastapi`, `gradio`, `langchain`, `chroma`, `llm`, `retrieval`


### PR DESCRIPTION
## Summary
- Align README’s prebuilt demo claim with actual `artifacts/` behavior and add rebuild note
- Add MIT `LICENSE`
- Document suggested GitHub “About” description/topics for portfolio polish

## Changes
- `README.md`: clarified prebuilt artifacts note; added repository metadata section
- `LICENSE`: added MIT license text

## Why
- Prevent confusion for users expecting a prebuilt demo
- Make licensing explicit and remove placeholder text
- Improve repo presentation and discoverability

## Verification
- Not run (docs/license change only)
