### PR TITLE
Improve first-run onboarding for local, Docker, and cloud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Required: OpenAI key used for embeddings and generation.
+OPENAI_API_KEY=sk-your-openai-key
+
+# Demo mode security settings.
+DEMO_MODE=1
+DEMO_API_KEY=demo-key-change-me
+
+# Optional: comma-separated allowed browser origins in demo mode.
+DEMO_CORS_ORIGINS=http://localhost:7860,http://127.0.0.1:7860
+
+# Optional runtime toggles.
+SHOW_GRADIO=1
+MAX_REQUEST_BYTES=50000
+API_BASE_URL=
+
+# Optional artifact paths (defaults point to ./artifacts/*).
+ARTIFACTS_DIR=artifacts
+VECTOR_DB_DIR=artifacts/vector_db
+MANIFEST_PATH=artifacts/manifest.json
+
+# Optional cloud deploy setting for CDK stack.
+OPENAI_SECRET_NAME=banking-rag/openai-api-key

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: help build-index dev docker
+
+help:
+	@echo "Available targets:"
+	@echo "  make build-index  - rebuild artifacts from data/"
+	@echo "  make dev          - run local FastAPI + Gradio app"
+	@echo "  make docker       - build and run Docker image using .env"
+
+build-index:
+	python -m src.pipeline.build_artifacts
+
+dev:
+	uvicorn src.server.app:app --host 0.0.0.0 --port 8000 --reload
+
+docker:
+	docker build -t banking-rag .
+	docker run --rm --env-file .env -p 8000:8000 banking-rag

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from typing import List, Tuple
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -23,6 +24,8 @@ app = FastAPI(
     docs_url="/api/docs",
     openapi_url="/api/openapi.json",
 )
+
+load_dotenv(override=False)
 
 _DEMO_MODE = os.getenv("DEMO_MODE", "").strip().lower() in {"1", "true", "yes", "on"}
 _DEMO_API_KEY = os.getenv("DEMO_API_KEY", "").strip()
@@ -50,13 +53,17 @@ app.add_middleware(
 _SHOW_GRADIO = os.getenv("SHOW_GRADIO", "").strip().lower() in {"1", "true", "yes", "on"}
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-ARTIFACTS_DIR = PROJECT_ROOT / "artifacts"
-VECTOR_DB_DIR = ARTIFACTS_DIR / "vector_db"
-MANIFEST_PATH = ARTIFACTS_DIR / "manifest.json"
+ARTIFACTS_DIR = Path(os.getenv("ARTIFACTS_DIR", str(PROJECT_ROOT / "artifacts"))).expanduser()
+VECTOR_DB_DIR = Path(
+    os.getenv("VECTOR_DB_DIR", str(ARTIFACTS_DIR / "vector_db"))
+).expanduser()
+MANIFEST_PATH = Path(
+    os.getenv("MANIFEST_PATH", str(ARTIFACTS_DIR / "manifest.json"))
+).expanduser()
 _READY_STATE: Tuple[bool, str] = (False, "Not initialized")
 _MISSING_ARTIFACTS_MESSAGE = (
     "Artifacts missing. This demo expects prebuilt artifacts. "
-    "Run: python -m src.build.build_index"
+    "Run: make build-index (or python -m src.pipeline.build_artifacts)"
 )
 def _check_artifacts() -> Tuple[bool, str]:
     if not VECTOR_DB_DIR.exists():


### PR DESCRIPTION
## Title
Make first-run setup foolproof (local + Docker + cloud)

## Why
New users could get stuck on first run because setup paths were split across docs and artifact-readiness behavior wasn’t explicit enough. This PR makes first-run deterministic and documents exact expected behavior.

## What changed

### 1) Added `.env.example` with required runtime config
Included all key variables for local/container/cloud setup:

- `OPENAI_API_KEY`
- `DEMO_MODE`
- `DEMO_API_KEY`
- `DEMO_CORS_ORIGINS`
- `SHOW_GRADIO`
- `MAX_REQUEST_BYTES`
- `API_BASE_URL`
- `ARTIFACTS_DIR`
- `VECTOR_DB_DIR`
- `MANIFEST_PATH`
- `OPENAI_SECRET_NAME` (cloud deploy convenience)

### 2) Added one-command happy paths via `Makefile`
- `make build-index` → rebuild artifacts
- `make dev` → run local FastAPI + mounted Gradio
- `make docker` → build image and run container with `.env`

### 3) Hardened artifact path/readiness wiring
Updated server config to support env-overridable artifact paths and clearer rebuild guidance:

- `ARTIFACTS_DIR`, `VECTOR_DB_DIR`, `MANIFEST_PATH` now configurable
- `/ready` missing-artifacts message now points to:
  - `make build-index`
  - `python -m src.pipeline.build_artifacts`

### 4) Reworked README first-run documentation
README now includes clear, copy-paste flows for:

- Local first run
- Docker first run
- Cloud first run (CDK/ECS)

Also documents `/ready` behavior with exact commands and expected `200` vs `503` outcomes.

## Definition of done coverage
- [x] New user can clone and configure from `.env.example`
- [x] One-command local startup path exists
- [x] One-command Docker path exists
- [x] One-command artifact rebuild exists
- [x] Missing-artifacts behavior is documented with expected outputs
- [x] `/ready` semantics are explicit and actionable

## Files changed
- `.env.example` (new)
- `Makefile` (new)
- `README.md`
- `src/server/app.py`

## Validation
- Python lint check passes for updated server module (`src/server/app.py`).
- Startup/readiness docs aligned with current runtime behavior and build command path.

## Issue
Closes #16 
