### PR TITLE
Add deterministic RAG reliability tests and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Byte-compile sources
         run: python -m compileall src
 
+      - name: Deterministic reliability tests
+        env:
+          DEMO_MODE: "0"
+          SHOW_GRADIO: "0"
+        run: pytest -q src/tests
+
       - name: Docker build
         run: docker build -t banking-rag-ci .
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ GitHub Actions workflow (`.github/workflows/ci.yml`) runs on pushes/PRs to `main
 
 - Ruff lint (`ruff check .`)
 - Python byte-compile (`python -m compileall src`)
+- deterministic reliability suite (`pytest -q src/tests`) covering API contracts, artifact manifest validation, and retrieval behavior
 - Docker build (`docker build -t banking-rag-ci .`)
 - optional evaluation smoke test when `OPENAI_API_KEY` secret is present
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "pytest>=8.3.0",
     "ruff>=0.7.0",
 ]

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+try:
+    import langchain_chroma  # noqa: F401
+except ModuleNotFoundError:
+    # Test-only fallback to keep imports deterministic in environments where
+    # langchain-chroma is not installed.
+    shim = types.ModuleType("langchain_chroma")
+
+    class _Chroma:  # pragma: no cover - only used when dependency is absent
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @classmethod
+        def from_documents(cls, *args, **kwargs):
+            return cls()
+
+        def as_retriever(self, *args, **kwargs):
+            return self
+
+        def invoke(self, *args, **kwargs):
+            return []
+
+        def delete_collection(self):
+            return None
+
+    shim.Chroma = _Chroma
+    sys.modules["langchain_chroma"] = shim
+
+
+@pytest.fixture
+def app_module(monkeypatch):
+    # Prevent demo-mode auth/startup behavior in tests.
+    monkeypatch.setenv("DEMO_MODE", "0")
+    monkeypatch.setenv("SHOW_GRADIO", "0")
+    monkeypatch.delenv("DEMO_API_KEY", raising=False)
+
+    module_name = "src.server.app"
+    if module_name in sys.modules:
+        module = importlib.reload(sys.modules[module_name])
+    else:
+        module = importlib.import_module(module_name)
+    return module

--- a/src/tests/test_api_contract.py
+++ b/src/tests/test_api_contract.py
@@ -1,0 +1,71 @@
+from fastapi.testclient import TestClient
+
+
+class _Doc:
+    def __init__(self, page_content, metadata):
+        self.page_content = page_content
+        self.metadata = metadata
+
+
+class _FakePipeline:
+    def answer_question(self, question, history, doc_type):  # pragma: no cover - simple stub
+        docs = [
+            _Doc(
+                page_content="ATM withdrawal fees may apply based on card type.",
+                metadata={"source": "fees.pdf", "doc_type": "product_terms"},
+            )
+        ]
+        return "ATM withdrawal fees depend on the account and card.", docs
+
+
+def _build_client(app_module, monkeypatch):
+    monkeypatch.setattr(app_module, "_check_artifacts", lambda: (True, "Ready"))
+    monkeypatch.setattr(app_module, "get_pipeline", lambda: _FakePipeline())
+    return TestClient(app_module.app)
+
+
+def test_health_endpoint_contract(app_module, monkeypatch):
+    with _build_client(app_module, monkeypatch) as client:
+        response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_ready_endpoint_returns_503_when_not_ready(app_module, monkeypatch):
+    with _build_client(app_module, monkeypatch) as client:
+        app_module._READY_STATE = (False, "Artifacts missing for test")
+        response = client.get("/ready")
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Artifacts missing for test"
+
+
+def test_ask_request_schema_validation(app_module, monkeypatch):
+    with _build_client(app_module, monkeypatch) as client:
+        payload = {
+            "question": "",
+            "doc_type": "product_terms",
+            "history": [],
+        }
+        response = client.post("/ask", json=payload)
+    assert response.status_code == 422
+    body = response.json()
+    assert body["detail"] == "Invalid request. Check question length, history length, and payload size."
+    assert "errors" in body
+
+
+def test_ask_response_contract(app_module, monkeypatch):
+    with _build_client(app_module, monkeypatch) as client:
+        payload = {
+            "question": "What ATM fees apply?",
+            "doc_type": "product_terms",
+            "history": [{"role": "user", "content": "Help me with card fees"}],
+        }
+        response = client.post("/ask", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body["answer"], str)
+    assert isinstance(body["sources"], list)
+    assert body["sources"][0]["source"] == "fees.pdf"
+    assert body["sources"][0]["doc_type"] == "product_terms"
+    assert "ATM withdrawal fees" in body["sources"][0]["preview"]

--- a/src/tests/test_manifest_golden.py
+++ b/src/tests/test_manifest_golden.py
@@ -1,0 +1,51 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+
+REQUIRED_FIELDS = {
+    "corpus_name": str,
+    "built_at": str,
+    "data_dir": str,
+    "document_count": int,
+    "document_types": dict,
+    "embedding_provider": str,
+    "embedding_model": str,
+    "chunk_size": int,
+    "chunk_overlap": int,
+    "vector_db_dir": str,
+}
+
+
+def test_manifest_exists():
+    manifest_path = Path("artifacts/manifest.json")
+    assert manifest_path.exists(), "artifacts/manifest.json is required for demo readiness"
+
+
+def test_manifest_has_required_fields_and_types():
+    manifest = json.loads(Path("artifacts/manifest.json").read_text(encoding="utf-8"))
+
+    for key, expected_type in REQUIRED_FIELDS.items():
+        assert key in manifest, f"Missing required manifest field: {key}"
+        assert isinstance(manifest[key], expected_type), (
+            f"Manifest field '{key}' must be of type {expected_type.__name__}"
+        )
+
+
+def test_manifest_semantic_constraints():
+    manifest = json.loads(Path("artifacts/manifest.json").read_text(encoding="utf-8"))
+
+    # Ensure built_at is parseable ISO-8601 timestamp.
+    datetime.fromisoformat(manifest["built_at"])
+
+    assert manifest["corpus_name"].strip()
+    assert manifest["document_count"] > 0
+    assert manifest["chunk_size"] > 0
+    assert 0 <= manifest["chunk_overlap"] < manifest["chunk_size"]
+    assert manifest["embedding_provider"] in {"openai", "huggingface"}
+    assert manifest["vector_db_dir"].strip()
+
+    document_types = manifest["document_types"]
+    assert document_types, "document_types must not be empty"
+    assert all(isinstance(k, str) and k for k in document_types.keys())
+    assert all(isinstance(v, int) and v >= 0 for v in document_types.values())

--- a/src/tests/test_retrieval_offline.py
+++ b/src/tests/test_retrieval_offline.py
@@ -1,0 +1,86 @@
+import re
+
+from src.retrieval.document_retriever import DocumentRetriever
+
+
+def _tokenize(text: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9]+", text.lower()))
+
+
+class _Doc:
+    def __init__(self, page_content, metadata):
+        self.page_content = page_content
+        self.metadata = metadata
+
+
+class _FakeVectorRetriever:
+    def __init__(self, docs, search_kwargs):
+        self.docs = docs
+        self.search_kwargs = search_kwargs
+
+    def invoke(self, query: str):
+        query_tokens = _tokenize(query)
+        top_k = self.search_kwargs.get("k", 5)
+        doc_type_filter = (self.search_kwargs.get("filter") or {}).get("doc_type")
+
+        scored = []
+        for doc in self.docs:
+            if doc_type_filter and doc.metadata.get("doc_type") != doc_type_filter:
+                continue
+            overlap = len(query_tokens & _tokenize(doc.page_content))
+            if overlap > 0:
+                scored.append((overlap, doc.metadata.get("source", ""), doc))
+
+        scored.sort(key=lambda row: (-row[0], row[1]))
+        return [row[2] for row in scored[:top_k]]
+
+
+class _FakeVectorStore:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def as_retriever(self, search_kwargs):
+        return _FakeVectorRetriever(self.docs, search_kwargs)
+
+
+def _build_retriever_with_corpus():
+    corpus = [
+        _Doc(
+            page_content="ATM withdrawal fees are charged for out-of-network cash withdrawals.",
+            metadata={"source": "fees_atm.pdf", "doc_type": "product_terms"},
+        ),
+        _Doc(
+            page_content="Debit order disputes must be raised within 40 days of the debit date.",
+            metadata={"source": "debit_disputes.pdf", "doc_type": "agreements"},
+        ),
+        _Doc(
+            page_content="Monthly account fee includes digital banking access and card maintenance.",
+            metadata={"source": "monthly_fees.pdf", "doc_type": "product_terms"},
+        ),
+    ]
+
+    retriever = DocumentRetriever.__new__(DocumentRetriever)
+    retriever._vectorstore = _FakeVectorStore(corpus)
+    return retriever
+
+
+def test_retrieval_top_k_returns_expected_docs():
+    retriever = _build_retriever_with_corpus()
+    results = retriever.retrieve(query="ATM withdrawal fee", top_k=2)
+
+    assert len(results) == 2
+    assert results[0].metadata["source"] == "fees_atm.pdf"
+    assert "ATM withdrawal fees" in results[0].page_content
+
+
+def test_retrieval_doc_type_filter_is_applied():
+    retriever = _build_retriever_with_corpus()
+    results = retriever.retrieve(
+        query="debit disputes",
+        top_k=3,
+        doc_type="agreements",
+    )
+
+    assert len(results) == 1
+    assert results[0].metadata["source"] == "debit_disputes.pdf"
+    assert results[0].metadata["doc_type"] == "agreements"

--- a/uv.lock
+++ b/uv.lock
@@ -247,6 +247,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -267,6 +268,7 @@ requires-dist = [
     { name = "mlflow", specifier = ">=2.16.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pypdf", specifier = ">=6.3.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "typer", specifier = ">=0.9" },
@@ -1406,6 +1408,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -2686,6 +2697,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "posthog"
 version = "5.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3105,6 +3125,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Title
Add deterministic RAG reliability test suite and CI gate (MVP trust baseline)

## Why
We already lint/compile/build in CI, but MVP reliability needs deterministic checks proving:
- service contract is stable
- artifacts are valid
- retrieval works

This PR adds offline tests that run on every PR without requiring LLM/network calls.

## What changed

### 1) API contract tests
Added `src/tests/test_api_contract.py` to validate:

- `GET /health` response contract
- `GET /ready` failure contract (`503` + detail)
- `POST /ask` request schema validation (`422` path)
- `POST /ask` response schema shape (with pipeline stubbed)

### 2) Retrieval-only deterministic tests
Added `src/tests/test_retrieval_offline.py` with a fixed in-test corpus and deterministic ranking checks:

- top-k retrieval returns expected source/doc
- `doc_type` filter is respected

No LLM calls required.

### 3) Golden artifact manifest tests
Added `src/tests/test_manifest_golden.py` to validate:

- `artifacts/manifest.json` exists
- required fields are present with expected types
- semantic constraints (ISO timestamp parseable, counts/chunk params sensible, known embedding provider values, non-empty document types)

### 4) Test bootstrap helpers
Added `src/tests/conftest.py`:

- forces non-demo defaults for deterministic API tests
- provides a lightweight `langchain_chroma` shim when missing, so tests remain stable across environments

### 5) CI integration
Updated `.github/workflows/ci.yml` to run deterministic reliability tests on every PR:

- `pytest -q src/tests`

Online eval remains optional and unchanged (still guarded by secret presence).

### 6) Dependencies and docs
- Added `pytest` to dev dependencies in `pyproject.toml` (lockfile updated in `uv.lock`)
- Updated `README.md` CI section to include deterministic reliability suite

## Definition of done mapping
- [x] CI proves service contract behavior (`/health`, `/ready`, `/ask` schema handling)
- [x] CI validates artifact manifest integrity
- [x] CI proves deterministic retrieval behavior
- [x] Online eval remains opt-in and non-blocking

## Validation run
- `uv run pytest -q src/tests` → passed
- `uv run ruff check src/tests src/server/app.py` → passed

## Files changed
- `.github/workflows/ci.yml`
- `README.md`
- `pyproject.toml`
- `uv.lock`
- `src/tests/conftest.py`
- `src/tests/test_api_contract.py`
- `src/tests/test_manifest_golden.py`
- `src/tests/test_retrieval_offline.py`

Closes #18 
